### PR TITLE
🎛️ Ajout de contrôles configurables pour la position iframe et synchronisation produits

### DIFF
--- a/modules/aismarttalk/classes/SynchProductsToAiSmartTalk.php
+++ b/modules/aismarttalk/classes/SynchProductsToAiSmartTalk.php
@@ -39,7 +39,7 @@ class SynchProductsToAiSmartTalk extends Module
         }
 
         // Si c'est une re-synchronisation forcée, nettoyer d'abord les produits en rupture de stock
-        if ($this->forceSync === true) {
+        if ($this->forceSync === true && $this->productIds) {
             $this->cleanOutOfStockProducts();
         }
 

--- a/modules/aismarttalk/translations/fr-FR/ModulesAismarttalkAdmin.fr-FR.xlf
+++ b/modules/aismarttalk/translations/fr-FR/ModulesAismarttalkAdmin.fr-FR.xlf
@@ -97,6 +97,76 @@
         <target>AI SmartTalk</target>
         <note>Line: </note>
       </trans-unit>
+      <trans-unit id="iframe_position_updated">
+        <source>Iframe position updated.</source>
+        <target>Position de l'iframe mise à jour.</target>
+        <note>Line: </note>
+      </trans-unit>
+      <trans-unit id="iframe_position_title">
+        <source>Iframe Position</source>
+        <target>Position de l'iframe</target>
+        <note>Line: </note>
+      </trans-unit>
+      <trans-unit id="iframe_position_description">
+        <source>Choose where to display the chatbot iframe on your website.</source>
+        <target>Choisissez où afficher l'iframe du chatbot sur votre site web.</target>
+        <note>Line: </note>
+      </trans-unit>
+      <trans-unit id="iframe_position_footer">
+        <source>In Footer</source>
+        <target>Dans le footer</target>
+        <note>Line: </note>
+      </trans-unit>
+      <trans-unit id="iframe_position_before_footer">
+        <source>Before Footer</source>
+        <target>Avant le footer</target>
+        <note>Line: </note>
+      </trans-unit>
+      <trans-unit id="save_position_settings">
+        <source>Save Position Settings</source>
+        <target>Enregistrer les paramètres de position</target>
+        <note>Line: </note>
+      </trans-unit>
+      <trans-unit id="settings_updated_no_sync">
+        <source>Settings updated. You can now enable product synchronization or use CSV import in AI SmartTalk.</source>
+        <target>Paramètres mis à jour. Vous pouvez maintenant activer la synchronisation des produits ou utiliser l'import CSV dans AI SmartTalk.</target>
+        <note>Line: </note>
+      </trans-unit>
+      <trans-unit id="product_sync_enabled">
+        <source>Product synchronization enabled. Products will automatically sync with AI SmartTalk.</source>
+        <target>Synchronisation des produits activée. Les produits se synchroniseront automatiquement avec AI SmartTalk.</target>
+        <note>Line: </note>
+      </trans-unit>
+      <trans-unit id="product_sync_disabled">
+        <source>Product synchronization disabled. You can use CSV import in AI SmartTalk instead.</source>
+        <target>Synchronisation des produits désactivée. Vous pouvez utiliser l'import CSV dans AI SmartTalk à la place.</target>
+        <note>Line: </note>
+      </trans-unit>
+      <trans-unit id="product_synchronization">
+        <source>Product Synchronization</source>
+        <target>Synchronisation des Produits</target>
+        <note>Line: </note>
+      </trans-unit>
+      <trans-unit id="product_sync_description">
+        <source>Choose how to manage your product data in AI SmartTalk. You can either enable automatic synchronization or use CSV import in the AI SmartTalk interface.</source>
+        <target>Choisissez comment gérer vos données produits dans AI SmartTalk. Vous pouvez soit activer la synchronisation automatique, soit utiliser l'import CSV dans l'interface AI SmartTalk.</target>
+        <note>Line: </note>
+      </trans-unit>
+      <trans-unit id="enable_product_sync">
+        <source>Enable Product Synchronization</source>
+        <target>Activer la synchronisation des produits</target>
+        <note>Line: </note>
+      </trans-unit>
+      <trans-unit id="product_sync_help">
+        <source>When enabled, products will automatically sync with AI SmartTalk when created, updated, or deleted. When disabled, you can use CSV import in AI SmartTalk.</source>
+        <target>Quand activé, les produits se synchroniseront automatiquement avec AI SmartTalk lors de leur création, modification ou suppression. Quand désactivé, vous pouvez utiliser l'import CSV dans AI SmartTalk.</target>
+        <note>Line: </note>
+      </trans-unit>
+      <trans-unit id="save_product_sync_settings">
+        <source>Save Product Sync Settings</source>
+        <target>Enregistrer les paramètres de synchronisation</target>
+        <note>Line: </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/modules/aismarttalk/views/templates/admin/backoffice.tpl
+++ b/modules/aismarttalk/views/templates/admin/backoffice.tpl
@@ -16,7 +16,7 @@
 <div class="panel">
   <h3><i class="icon icon-cogs"></i> {l s='AI SmartTalk Configuration' mod='aismarttalk'}</h3>
   <div class="row">
-      <div class="col-md-6">
+      <div class="col-md-12">
           <div class="panel">
               <div class="panel-heading">
                   <h4>{l s='Customer Synchronization' mod='aismarttalk'}</h4>
@@ -48,21 +48,6 @@
                           </div>
                       </div>
                   </form>
-              </div>
-          </div>
-      </div>
-      <div class="col-md-6">
-          <div class="panel">
-              <div class="panel-heading">
-                  {l s='Product Synchronization' mod='aismarttalk'}
-              </div>
-              <div class="panel-body">
-                  <a href="{$smarty.server.REQUEST_URI|escape:'html':'UTF-8'}&amp;forceSync=false" class="btn btn-default">
-                      <i class="icon icon-refresh"></i> {l s='Synchronize New Products' mod='aismarttalk'}
-                  </a>
-                  <a href="{$smarty.server.REQUEST_URI|escape:'html':'UTF-8'}&amp;forceSync=true" class="btn btn-default">
-                      <i class="icon icon-refresh"></i> {l s='Re-Synchronize All Products' mod='aismarttalk'}
-                  </a>
               </div>
           </div>
       </div>


### PR DESCRIPTION
### Description

Cette PR ajoute deux nouvelles fonctionnalités de configuration pour améliorer la flexibilité du module :

**✨ Nouvelles fonctionnalités :**
- 📍 **Position iframe configurable** : Choix entre "Dans le footer" et "Avant le footer" via `displayBeforeFooter` hook
- 🔄 **Synchronisation produits optionnelle** : Désactivée par défaut, permet d'utiliser l'import CSV comme alternative
- 🎯 **Réorganisation de l'interface admin** : Meilleure organisation des formulaires de configuration

**🔧 Modifications techniques :**
- Ajout des configurations `AI_SMART_TALK_IFRAME_POSITION` et `AI_SMART_TALK_PRODUCT_SYNC`
- Hook `displayBeforeFooter` enregistré et géré
- Vérification de l'option sync avant chaque action produit (create/update/delete)
- Bouton de re-synchronisation manuelle déplacé dans le formulaire de sync produits
- Suppression de la synchronisation automatique lors de la configuration initiale

**🌍 Traductions :**
- Ajout des nouvelles clés de traduction en français

**📦 Version :** `2.2.3` → `2.3.0`