### PR TITLE
✨ Show assistant name & avatar in admin, bump to v3.4.2

### DIFF
--- a/modules/aismarttalk/aismarttalk.php
+++ b/modules/aismarttalk/aismarttalk.php
@@ -47,7 +47,7 @@ class AiSmartTalk extends Module
     {
         $this->name = 'aismarttalk';
         $this->tab = 'front_office_features';
-        $this->version = '3.4.1';
+        $this->version = '3.4.2';
         $this->author = 'AI SmartTalk';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = [
@@ -358,10 +358,11 @@ class AiSmartTalk extends Module
             $chatModelId, $lang, $frontendApiUrl, $cdnUrl, $wsUrl, $embedConfig
         );
 
-        // Extract avatar URLs for admin display
+        // Extract avatar URLs and chat model info for admin display
         $embedConfigAvatarUrl = ChatbotSettingsBuilder::getEmbedConfigAvatarUrl($embedConfig);
         $localAvatarUrl = Configuration::get('AI_SMART_TALK_AVATAR_URL') ?: '';
         $effectiveAvatarUrl = !empty($localAvatarUrl) ? $localAvatarUrl : $embedConfigAvatarUrl;
+        $chatModelInfo = $this->fetchChatModelInfo();
 
         // Get cache metadata for display
         $cacheMetadata = AiSmartTalkCache::getMetadata('embed_config');
@@ -422,7 +423,9 @@ class AiSmartTalk extends Module
             'avatarUrl' => $localAvatarUrl,
             'embedConfigAvatarUrl' => $embedConfigAvatarUrl,
             'effectiveAvatarUrl' => $effectiveAvatarUrl,
-            'chatModelAvatarUrl' => $this->fetchChatModelAvatar() ?: '',
+            'chatModelAvatarUrl' => $chatModelInfo['avatarUrl'] ?: '',
+            'chatModelName' => $chatModelInfo['name']
+                ?: (is_array($embedConfig) && !empty($embedConfig['name']) ? $embedConfig['name'] : ''),
             'buttonPosition' => Configuration::get('AI_SMART_TALK_BUTTON_POSITION') ?: '',
             'chatSize' => Configuration::get('AI_SMART_TALK_CHAT_SIZE') ?: '',
             'colorMode' => Configuration::get('AI_SMART_TALK_COLOR_MODE') ?: '',
@@ -634,34 +637,52 @@ class AiSmartTalk extends Module
     }
 
     /**
-     * Fetch the chat model avatar from the API with caching
+     * Fetch the chat model info (avatar + name) from the API with caching
      *
      * @param bool $forceRefresh Force refresh from API
-     * @return string|null The avatar URL or null if not available
+     * @return array{avatarUrl: string|null, name: string|null}
      */
-    private function fetchChatModelAvatar(bool $forceRefresh = false)
+    private function fetchChatModelInfo(bool $forceRefresh = false): array
     {
+        $default = ['avatarUrl' => null, 'name' => null];
+
         if (!$forceRefresh) {
-            $cached = AiSmartTalkCache::get('chat_model_avatar');
-            if ($cached !== null) {
+            $cached = AiSmartTalkCache::get('chat_model_info');
+            if (is_array($cached)) {
                 return $cached;
             }
         }
 
         $client = ApiClient::fromConfig();
         if (!$client->hasCredentials()) {
-            return null;
+            return $default;
         }
 
         $response = $client->get('/api/v1/chatModel/' . urlencode($client->getChatModelId()) . '/avatar');
 
-        $avatarUrl = $response->get('data.avatarUrl');
-        if ($response->isSuccess() && $avatarUrl) {
-            AiSmartTalkCache::set('chat_model_avatar', $avatarUrl, 3600);
-            return $avatarUrl;
+        if (!$response->isSuccess()) {
+            return $default;
         }
 
-        return null;
+        $info = [
+            'avatarUrl' => $response->get('data.avatarUrl') ?: null,
+            'name' => $response->get('data.chatModelName') ?: null,
+        ];
+
+        AiSmartTalkCache::set('chat_model_info', $info, 3600);
+
+        return $info;
+    }
+
+    /**
+     * Fetch the chat model avatar from the API with caching (convenience wrapper)
+     *
+     * @param bool $forceRefresh Force refresh from API
+     * @return string|null The avatar URL or null if not available
+     */
+    private function fetchChatModelAvatar(bool $forceRefresh = false)
+    {
+        return $this->fetchChatModelInfo($forceRefresh)['avatarUrl'];
     }
 
     /**

--- a/modules/aismarttalk/config.xml
+++ b/modules/aismarttalk/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>aismarttalk</name>
     <displayName><![CDATA[AI SmartTalk]]></displayName>
-    <version><![CDATA[3.4.1]]></version>
+    <version><![CDATA[3.4.2]]></version>
     <description><![CDATA[https://aismarttalk.tech/]]></description>
     <author><![CDATA[AI SmartTalk]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/modules/aismarttalk/views/templates/admin/configure.tpl
+++ b/modules/aismarttalk/views/templates/admin/configure.tpl
@@ -1656,9 +1656,15 @@ a.ast-btn-success:hover {
                         </div>
                         <div class="ast-card-body">
                             <div class="ast-stat-card" style="margin-bottom: 20px;">
-                                <div class="ast-stat-icon">💬</div>
-                                <div class="ast-stat-label">{l s='Chat Model' mod='aismarttalk'}</div>
-                                <div class="ast-stat-value" style="font-size: 14px; word-break: break-all;">{$chatModelId|escape:'html':'UTF-8'|truncate:20:'...'}</div>
+                                {if $chatModelAvatarUrl}
+                                    <img src="{$chatModelAvatarUrl|escape:'html':'UTF-8'}" alt="" style="width: 40px; height: 40px; border-radius: 50%; object-fit: cover;">
+                                {else}
+                                    <div class="ast-stat-icon">💬</div>
+                                {/if}
+                                <div class="ast-stat-label">{l s='Assistant' mod='aismarttalk'}</div>
+                                <div class="ast-stat-value" style="font-size: 15px;">
+                                    {if $chatModelName}{$chatModelName|escape:'html':'UTF-8'}{else}{$chatModelId|escape:'html':'UTF-8'|truncate:20:'...'}{/if}
+                                </div>
                             </div>
                             <a href="{$backofficeUrl|escape:'html':'UTF-8'}" target="_blank" class="ast-btn ast-btn-primary" style="width: 100%; justify-content: center;">
                                 <i class="icon icon-external-link"></i>
@@ -1801,6 +1807,27 @@ a.ast-btn-success:hover {
 
             {* ===== TAB 2: APPEARANCE ===== *}
             <div class="ast-panel" id="panel-appearance" role="tabpanel">
+                <div class="ast-card" style="margin-bottom: 20px;">
+                    <div class="ast-card-header">
+                        <h3><i class="icon icon-user"></i> {l s='Assistant' mod='aismarttalk'}</h3>
+                    </div>
+                    <div class="ast-card-body">
+                        <div style="display: flex; align-items: center; gap: 16px;">
+                            {if $chatModelAvatarUrl}
+                                <img src="{$chatModelAvatarUrl|escape:'html':'UTF-8'}" alt="" style="width: 48px; height: 48px; border-radius: 50%; object-fit: cover; flex-shrink: 0;">
+                            {else}
+                                <div class="ast-stat-icon" style="flex-shrink: 0;">💬</div>
+                            {/if}
+                            <div>
+                                <div style="font-weight: 600; font-size: 16px; color: #1e293b;">
+                                    {if $chatModelName}{$chatModelName|escape:'html':'UTF-8'}{else}{$chatModelId|escape:'html':'UTF-8'|truncate:20:'...'}{/if}
+                                </div>
+                                <div style="color: #64748b; font-size: 13px; margin-top: 2px;">{l s='Your AI assistant' mod='aismarttalk'}</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <form action="{$formAction|escape:'html':'UTF-8'}" method="post" enctype="multipart/form-data">
                     <div class="ast-card">
                         <div class="ast-card-header">
@@ -2627,12 +2654,12 @@ document.addEventListener('DOMContentLoaded', function() {
             // Save to localStorage
             localStorage.setItem('ast_active_tab', this.dataset.tab);
 
-            // Show/hide chatbot widget only on the sync tab
+            // Show/hide chatbot widget only on the appearance tab
             toggleChatbotVisibility(this.dataset.tab);
         });
     });
 
-    // Show/hide chatbot widget only on the sync tab (use a <style> tag to avoid
+    // Show/hide chatbot widget only on the appearance tab (use a <style> tag to avoid
     // toggling display which can re-trigger the widget open animation)
     var astHideStyle = document.createElement('style');
     astHideStyle.id = 'ast-hide-chatbot-widget';
@@ -2645,7 +2672,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function toggleChatbotVisibility(tab) {
-        astHideStyle.disabled = (tab === 'sync');
+        astHideStyle.disabled = (tab === 'appearance');
     }
 
     // Restore last active tab


### PR DESCRIPTION
## Summary

- Display assistant **name and avatar** in the Chatbot Overview card instead of a truncated chat model ID
- Fetch chat model name from `/api/v1/chatModel/:id/avatar` endpoint (`chatModelName` field), with embed-config `name` as fallback
- Add assistant identity card to the Appearance tab
- Show chatbot preview widget on Appearance tab instead of Sync tab
- Bump version to **v3.4.2**

## Changes

### PHP (`aismarttalk.php`)
- New `fetchChatModelInfo()` method returns `{avatarUrl, name}` (replaces `fetchChatModelAvatar()` which is now a wrapper)
- Cache key changed from `chat_model_avatar` (string) to `chat_model_info` (array)
- Pass `chatModelName` to Smarty template with embed-config fallback

### Template (`configure.tpl`)
- Overview card: avatar image + assistant name (fallback to truncated ID)
- New assistant identity card on Appearance tab
- Chatbot preview visible on Appearance tab instead of Sync tab

## Test plan
- [ ] Verify assistant name displays in Overview card (Chatbot tab)
- [ ] Verify avatar displays when available
- [ ] Verify fallback to truncated ID when name is unavailable
- [ ] Verify chatbot preview appears on Appearance tab
- [ ] Test on PrestaShop 1.7 and 8.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)