### PR TITLE
v3.5.0: Always-on encryption, fix sync filters, admin UX

### DIFF
--- a/modules/aismarttalk/aismarttalk.php
+++ b/modules/aismarttalk/aismarttalk.php
@@ -47,7 +47,7 @@ class AiSmartTalk extends Module
     {
         $this->name = 'aismarttalk';
         $this->tab = 'front_office_features';
-        $this->version = '3.4.2';
+        $this->version = '3.5.0';
         $this->author = 'AI SmartTalk';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = [
@@ -85,7 +85,6 @@ class AiSmartTalk extends Module
             'AI_SMART_TALK_PRODUCT_SYNC' => false,
             'AI_SMART_TALK_CUSTOMER_SYNC' => false,
             'AI_SMART_TALK_CUSTOMER_SYNC_CONSENT' => 'all',
-            'AI_SMART_TALK_ENCRYPT_PAYLOADS' => true,
         ];
 
         foreach ($defaults as $key => $value) {
@@ -247,7 +246,6 @@ class AiSmartTalk extends Module
             // Customer sync
             && Configuration::deleteByName('AI_SMART_TALK_CUSTOMER_SYNC')
             && Configuration::deleteByName('AI_SMART_TALK_CUSTOMER_SYNC_CONSENT')
-            && Configuration::deleteByName('AI_SMART_TALK_ENCRYPT_PAYLOADS')
             // GDPR settings
             && Configuration::deleteByName('AI_SMART_TALK_GDPR_ENABLED')
             && Configuration::deleteByName('AI_SMART_TALK_GDPR_PRIVACY_URL')
@@ -358,11 +356,8 @@ class AiSmartTalk extends Module
             $chatModelId, $lang, $frontendApiUrl, $cdnUrl, $wsUrl, $embedConfig
         );
 
-        // Extract avatar URLs and chat model info for admin display
-        $embedConfigAvatarUrl = ChatbotSettingsBuilder::getEmbedConfigAvatarUrl($embedConfig);
-        $localAvatarUrl = Configuration::get('AI_SMART_TALK_AVATAR_URL') ?: '';
-        $effectiveAvatarUrl = !empty($localAvatarUrl) ? $localAvatarUrl : $embedConfigAvatarUrl;
-        $chatModelInfo = $this->fetchChatModelInfo();
+        // Fetch chat model info (always fresh in admin — cheap API call, avoids stale avatar)
+        $chatModelInfo = $this->fetchChatModelInfo(true);
 
         // Get cache metadata for display
         $cacheMetadata = AiSmartTalkCache::getMetadata('embed_config');
@@ -388,9 +383,10 @@ class AiSmartTalk extends Module
 
             // Sync settings
             'productSyncEnabled' => (bool) Configuration::get('AI_SMART_TALK_PRODUCT_SYNC'),
+            'hasExistingProductSync' => !empty(AiSmartTalkProductSync::getSyncedProductIds((int) $this->context->shop->id)),
             'customerSyncEnabled' => (bool) Configuration::get('AI_SMART_TALK_CUSTOMER_SYNC'),
+            'hasExistingCustomerSync' => !empty(AiSmartTalkCustomerSync::getSyncedCustomerIds()),
             'customerSyncConsent' => Configuration::get('AI_SMART_TALK_CUSTOMER_SYNC_CONSENT') ?: 'all',
-            'encryptPayloads' => (bool) Configuration::get('AI_SMART_TALK_ENCRYPT_PAYLOADS'),
 
             // Sync filter settings
             'syncFilterConfig' => $syncFilterConfig,
@@ -420,9 +416,6 @@ class AiSmartTalk extends Module
             // Chatbot customization settings
             'buttonText' => Configuration::get('AI_SMART_TALK_BUTTON_TEXT') ?: '',
             'buttonType' => Configuration::get('AI_SMART_TALK_BUTTON_TYPE') ?: '',
-            'avatarUrl' => $localAvatarUrl,
-            'embedConfigAvatarUrl' => $embedConfigAvatarUrl,
-            'effectiveAvatarUrl' => $effectiveAvatarUrl,
             'chatModelAvatarUrl' => $chatModelInfo['avatarUrl'] ?: '',
             'chatModelName' => $chatModelInfo['name']
                 ?: (is_array($embedConfig) && !empty($embedConfig['name']) ? $embedConfig['name'] : ''),
@@ -1007,8 +1000,11 @@ class AiSmartTalk extends Module
             }
 
             // Sync product if it hasn't been synced yet (new product or restock)
+            // and it matches category filters
+            $shopId = (int) $this->context->shop->id;
             if ((bool) Configuration::get('AI_SMART_TALK_PRODUCT_SYNC')
                 && !AiSmartTalkProductSync::isSynced($idProduct)
+                && SyncFilterHelper::shouldProductBeSynced($idProduct, $shopId)
             ) {
                 $api = new SynchProductsToAiSmartTalk($this->context);
                 $api(['productIds' => [(string) $idProduct], 'forceSync' => true]);
@@ -1499,7 +1495,6 @@ class AiSmartTalk extends Module
         $settingsToCheck = [
             'AI_SMART_TALK_BUTTON_TEXT',
             'AI_SMART_TALK_BUTTON_TYPE',
-            'AI_SMART_TALK_AVATAR_URL',
             'AI_SMART_TALK_BUTTON_POSITION',
             'AI_SMART_TALK_CHAT_SIZE',
             'AI_SMART_TALK_COLOR_MODE',

--- a/modules/aismarttalk/classes/AdminFormHandler.php
+++ b/modules/aismarttalk/classes/AdminFormHandler.php
@@ -268,12 +268,14 @@ class AdminFormHandler
             $buttonType = '';
         }
 
-        // Handle avatar file upload
-        $avatarUrl = \Configuration::get('AI_SMART_TALK_AVATAR_URL') ?: '';
+        // Handle avatar file upload (uploaded to platform API, not stored locally)
         if (isset($_FILES['AI_SMART_TALK_AVATAR_FILE']) && $_FILES['AI_SMART_TALK_AVATAR_FILE']['error'] === UPLOAD_ERR_OK) {
             $uploadResult = $this->uploadChatModelAvatarFile($_FILES['AI_SMART_TALK_AVATAR_FILE']);
             if ($uploadResult['success']) {
-                $avatarUrl = $uploadResult['avatarUrl'];
+                // Clear any stale local avatar URL — the platform is the source of truth
+                \Configuration::updateValue('AI_SMART_TALK_AVATAR_URL', '');
+                AiSmartTalkCache::delete('embed_config');
+                AiSmartTalkCache::delete('chat_model_info');
                 $output .= $this->module->displayConfirmation(
                     $this->trans('Avatar uploaded successfully.', [], 'Modules.Aismarttalk.Admin')
                 );
@@ -346,9 +348,9 @@ class AdminFormHandler
         }
 
         // Save all customization settings
+        // Note: AI_SMART_TALK_AVATAR_URL is not saved here — avatar is managed on the platform
         \Configuration::updateValue('AI_SMART_TALK_BUTTON_TEXT', pSQL($buttonText));
         \Configuration::updateValue('AI_SMART_TALK_BUTTON_TYPE', $buttonType);
-        \Configuration::updateValue('AI_SMART_TALK_AVATAR_URL', pSQL($avatarUrl));
         \Configuration::updateValue('AI_SMART_TALK_BUTTON_POSITION', $buttonPosition);
         \Configuration::updateValue('AI_SMART_TALK_CHAT_SIZE', $chatSize);
         \Configuration::updateValue('AI_SMART_TALK_COLOR_MODE', $colorMode);
@@ -404,9 +406,6 @@ class AdminFormHandler
             $consentFilter = 'all';
         }
         \Configuration::updateValue('AI_SMART_TALK_CUSTOMER_SYNC_CONSENT', $consentFilter);
-
-        $encryptPayloads = (bool) \Tools::getValue('AI_SMART_TALK_ENCRYPT_PAYLOADS');
-        \Configuration::updateValue('AI_SMART_TALK_ENCRYPT_PAYLOADS', $encryptPayloads);
 
         // Handle sync filters in the same form submission
         $categoryMode = \Tools::getValue('sync_filter_category_mode', '');
@@ -604,6 +603,7 @@ class AdminFormHandler
     private function handleRefreshEmbedConfig(): string
     {
         AiSmartTalkCache::delete('embed_config');
+        AiSmartTalkCache::delete('chat_model_info');
 
         $client = ApiClient::fromConfig();
         if (!$client->hasCredentials()) {

--- a/modules/aismarttalk/classes/ChatbotSettingsBuilder.php
+++ b/modules/aismarttalk/classes/ChatbotSettingsBuilder.php
@@ -153,10 +153,10 @@ class ChatbotSettingsBuilder
     public static function applyCustomizationOverrides(array $settings): array
     {
         // Text/select overrides (only if non-empty)
+        // Note: avatarUrl is NOT overridden locally — the platform embed config is the source of truth
         $textOverrides = [
             'AI_SMART_TALK_BUTTON_TEXT' => 'buttonText',
             'AI_SMART_TALK_BUTTON_TYPE' => 'buttonType',
-            'AI_SMART_TALK_AVATAR_URL' => 'avatarUrl',
             'AI_SMART_TALK_BUTTON_POSITION' => 'position',
             'AI_SMART_TALK_CHAT_SIZE' => 'chatSize',
             'AI_SMART_TALK_COLOR_MODE' => 'initialColorMode',

--- a/modules/aismarttalk/classes/PayloadEncryptor.php
+++ b/modules/aismarttalk/classes/PayloadEncryptor.php
@@ -30,28 +30,18 @@ class PayloadEncryptor
     private const HKDF_INFO = 'aismarttalk-payload-encryption-v1';
 
     /**
-     * Check if payload encryption is enabled.
-     *
-     * @return bool
-     */
-    public static function isEnabled()
-    {
-        return (bool) \Configuration::get('AI_SMART_TALK_ENCRYPT_PAYLOADS');
-    }
-
-    /**
      * Encrypt a payload array. Returns the encrypted envelope.
-     * If encryption is disabled, returns null (caller should send plain).
+     * Returns null only if credentials are missing or encryption fails.
      *
      * @param array  $payload     The data to encrypt (will be JSON-encoded)
      * @param string $token       The access token (used to derive key)
      * @param string $chatModelId The chat model ID (used as HKDF salt)
      *
-     * @return array|null Encrypted envelope {v, iv, tag, data} or null if disabled
+     * @return array|null Encrypted envelope {v, iv, tag, data} or null on failure
      */
     public static function encrypt(array $payload, $token, $chatModelId)
     {
-        if (!self::isEnabled() || empty($token) || empty($chatModelId)) {
+        if (empty($token) || empty($chatModelId)) {
             return null;
         }
 

--- a/modules/aismarttalk/classes/SynchProductsToAiSmartTalk.php
+++ b/modules/aismarttalk/classes/SynchProductsToAiSmartTalk.php
@@ -218,8 +218,7 @@ class SynchProductsToAiSmartTalk
             LEFT JOIN ' . _DB_PREFIX_ . 'aismarttalk_product_sync aps ON p.id_product = aps.id_product
                 AND aps.id_shop = ' . $defaultShopId . '
             WHERE pl.id_lang = ' . $defaultLangId . ' AND cl.id_lang = ' . $defaultLangId . ' AND p.active = 1
-                AND COALESCE(sa.quantity, 0) > 0
-            GROUP BY p.id_product';
+                AND COALESCE(sa.quantity, 0) > 0';
 
         // If not forcing sync, only get products that are not yet synced
         if ($this->forceSync === false) {
@@ -237,6 +236,8 @@ class SynchProductsToAiSmartTalk
         if (!empty($categoryFilter)) {
             $sql .= $categoryFilter;
         }
+
+        $sql .= ' GROUP BY p.id_product';
 
         $products = \Db::getInstance()->executeS($sql);
 

--- a/modules/aismarttalk/config_fr.xml
+++ b/modules/aismarttalk/config_fr.xml
@@ -3,13 +3,11 @@
     <name>aismarttalk</name>
     <displayName><![CDATA[AI SmartTalk]]></displayName>
     <version><![CDATA[3.5.0]]></version>
-    <description><![CDATA[https://aismarttalk.tech/]]></description>
+    <description><![CDATA[Int&eacute;grez le chatbot AI SmartTalk pour am&eacute;liorer le support client et l&#039;engagement.]]></description>
     <author><![CDATA[AI SmartTalk]]></author>
     <tab><![CDATA[front_office_features]]></tab>
+	<confirmUninstall><![CDATA[Êtes-vous sûr de vouloir désinstaller ?]]></confirmUninstall>
     <is_configurable>1</is_configurable>
     <need_instance>0</need_instance>
-    <limited_countries></limited_countries>
-    <translations>
-        <translation key="Modules.Aismarttalk.Admin" dir="translations" />
-    </translations>
+	<limited_countries></limited_countries>
 </module>

--- a/modules/aismarttalk/upgrade/upgrade-3.5.0.php
+++ b/modules/aismarttalk/upgrade/upgrade-3.5.0.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright (c) 2026 AI SmartTalk
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ *
+ * @author    AI SmartTalk <contact@aismarttalk.tech>
+ * @copyright 2026 AI SmartTalk
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Upgrade module to 3.5.0
+ * - Payload encryption is now always active — remove the optional config key.
+ * - Clear stale local avatar URL — avatar is now sourced from the platform embed config.
+ */
+function upgrade_module_3_5_0($module)
+{
+    Configuration::deleteByName('AI_SMART_TALK_ENCRYPT_PAYLOADS');
+    Configuration::deleteByName('AI_SMART_TALK_AVATAR_URL');
+
+    return true;
+}

--- a/modules/aismarttalk/views/templates/admin/backoffice.tpl
+++ b/modules/aismarttalk/views/templates/admin/backoffice.tpl
@@ -55,17 +55,13 @@
                       </div>
                       <div class="form-group">
                           <label class="control-label col-lg-4">
-                              {l s='Encrypt Payloads' mod='aismarttalk'}
+                              {l s='Payload Encryption' mod='aismarttalk'}
                           </label>
                           <div class="col-lg-8">
-                              <div class="switch prestashop-switch">
-                                  <input type="radio" name="AI_SMART_TALK_ENCRYPT_PAYLOADS" id="AI_SMART_TALK_ENCRYPT_PAYLOADS_on" value="1" {if $encryptPayloads}checked="checked"{/if}>
-                                  <label for="AI_SMART_TALK_ENCRYPT_PAYLOADS_on">{l s='Yes' mod='aismarttalk'}</label>
-                                  <input type="radio" name="AI_SMART_TALK_ENCRYPT_PAYLOADS" id="AI_SMART_TALK_ENCRYPT_PAYLOADS_off" value="0" {if !$encryptPayloads}checked="checked"{/if}>
-                                  <label for="AI_SMART_TALK_ENCRYPT_PAYLOADS_off">{l s='No' mod='aismarttalk'}</label>
-                                  <a class="slide-button btn"></a>
-                              </div>
-                              <p class="help-block">{l s='AES-256-GCM encryption for customer data in transit' mod='aismarttalk'}</p>
+                              <p class="form-control-static" style="color: #27ae60; font-weight: 600;">
+                                  <i class="icon icon-check-circle"></i> {l s='Always active' mod='aismarttalk'}
+                              </p>
+                              <p class="help-block">{l s='All data is encrypted with AES-256-GCM before transmission.' mod='aismarttalk'}</p>
                           </div>
                       </div>
                       {/if}

--- a/modules/aismarttalk/views/templates/admin/configure.tpl
+++ b/modules/aismarttalk/views/templates/admin/configure.tpl
@@ -527,6 +527,102 @@ a.ast-btn-warning:hover {
     background: #e2e8f0;
     color: #334155 !important;
 }
+/* Confirm Modal */
+.ast-modal-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.6);
+    backdrop-filter: blur(4px);
+    z-index: 99999;
+    justify-content: center;
+    align-items: center;
+    animation: ast-fade-in 0.2s ease;
+}
+.ast-modal-overlay.active { display: flex; }
+@keyframes ast-fade-in { from { opacity: 0; } to { opacity: 1; } }
+@keyframes ast-modal-in { from { opacity: 0; transform: scale(0.95) translateY(10px); } to { opacity: 1; transform: scale(1) translateY(0); } }
+.ast-modal {
+    background: #fff;
+    border-radius: 16px;
+    box-shadow: 0 25px 60px rgba(0,0,0,0.2);
+    max-width: 440px;
+    width: 90%;
+    animation: ast-modal-in 0.25s ease;
+    overflow: hidden;
+}
+.ast-modal-icon {
+    width: 56px;
+    height: 56px;
+    border-radius: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    margin: 0 auto 16px;
+}
+.ast-modal-icon.warning {
+    background: linear-gradient(135deg, #fef3c7, #fde68a);
+    color: #d97706;
+}
+.ast-modal-icon.clean {
+    background: linear-gradient(135deg, #f1f5f9, #e2e8f0);
+    color: #64748b;
+}
+.ast-modal-header {
+    padding: 28px 28px 0;
+    text-align: center;
+}
+.ast-modal-header h3 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 700;
+    color: #1e293b;
+}
+.ast-modal-body {
+    padding: 12px 28px 0;
+    text-align: center;
+}
+.ast-modal-body p {
+    margin: 0;
+    font-size: 14px;
+    color: #64748b;
+    line-height: 1.6;
+}
+.ast-modal-footer {
+    padding: 24px 28px 28px;
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+}
+.ast-modal-btn {
+    padding: 10px 24px;
+    border-radius: 10px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    border: none;
+    transition: all 0.15s ease;
+}
+.ast-modal-btn:hover { transform: translateY(-1px); }
+.ast-modal-btn.cancel {
+    background: #f1f5f9;
+    color: #475569;
+}
+.ast-modal-btn.cancel:hover { background: #e2e8f0; }
+.ast-modal-btn.confirm-warning {
+    background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+    color: #fff;
+    box-shadow: 0 4px 12px rgba(245, 158, 11, 0.3);
+}
+.ast-modal-btn.confirm-warning:hover { box-shadow: 0 6px 16px rgba(245, 158, 11, 0.4); }
+.ast-modal-btn.confirm-clean {
+    background: linear-gradient(135deg, #64748b 0%, #475569 100%);
+    color: #fff;
+    box-shadow: 0 4px 12px rgba(100, 116, 139, 0.3);
+}
+.ast-modal-btn.confirm-clean:hover { box-shadow: 0 6px 16px rgba(100, 116, 139, 0.4); }
+
 .ast-action-customer {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: #fff !important;
@@ -1862,6 +1958,20 @@ a.ast-btn-success:hover {
                                 </label>
                             </div>
 
+                            {if $chatModelId}
+                            <div class="ast-avatar-hint" id="ast-avatar-hint" style="display:{if $buttonType == 'avatar'}flex{else}none{/if}; align-items:center; gap:6px; margin-top:12px; padding:8px 12px; background:#f0f4f8; border-radius:6px; font-size:12px; color:#637381;">
+                                <i class="icon icon-external-link" style="font-size:11px; color:#95a5b6;"></i>
+                                <span>
+                                    {l s='Customize your avatar (or generate one with AI) on' mod='aismarttalk'}
+                                    <a href="https://aismarttalk.tech/{$currentLang|escape:'html':'UTF-8'}/admin/chatModel/{$chatModelId|escape:'html':'UTF-8'}/settings/theme"
+                                       target="_blank" rel="noopener noreferrer"
+                                       style="color:#3f8cff; text-decoration:none; font-weight:500;">
+                                        AI SmartTalk
+                                    </a>
+                                </span>
+                            </div>
+                            {/if}
+
                             <div class="ast-form-group" style="margin-top: 20px;">
                                 <label class="ast-label">{l s='Button Text' mod='aismarttalk'}</label>
                                 <input type="text" name="AI_SMART_TALK_BUTTON_TEXT" value="{$buttonText|escape:'html':'UTF-8'}" class="ast-input" placeholder="{l s='e.g., Need help?' mod='aismarttalk'}">
@@ -2208,13 +2318,10 @@ a.ast-btn-success:hover {
 
                                     <div class="ast-toggle-card">
                                         <div class="ast-toggle-info">
-                                            <h4><i class="icon icon-lock" style="color: #667eea; margin-right: 4px;"></i> {l s='Encrypt Payloads' mod='aismarttalk'}</h4>
-                                            <p>{l s='AES-256-GCM encryption for data in transit' mod='aismarttalk'}</p>
+                                            <h4><i class="icon icon-lock" style="color: #667eea; margin-right: 4px;"></i> {l s='Payload Encryption' mod='aismarttalk'}</h4>
+                                            <p>{l s='All data is encrypted with AES-256-GCM before transmission.' mod='aismarttalk'}</p>
                                         </div>
-                                        <label class="ast-switch">
-                                            <input type="checkbox" name="AI_SMART_TALK_ENCRYPT_PAYLOADS" value="1" {if $encryptPayloads}checked{/if}>
-                                            <span class="ast-switch-slider"></span>
-                                        </label>
+                                        <span style="color: #27ae60; font-weight: 600; font-size: 13px;"><i class="icon icon-check-circle" style="margin-right: 4px;"></i>{l s='Always active' mod='aismarttalk'}</span>
                                     </div>
                                 </div>
                                 {/if}
@@ -2242,11 +2349,11 @@ a.ast-btn-success:hover {
                         </div>
                         <div class="ast-card-body" style="padding: 12px 24px 24px;">
                             <div class="ast-sync-actions">
-                                <a href="{$formAction|escape:'html':'UTF-8'}&amp;forceSync=true" class="ast-action-btn ast-action-product">
+                                <a href="{$formAction|escape:'html':'UTF-8'}&amp;forceSync=true" class="ast-action-btn ast-action-product" {if $hasExistingProductSync}onclick="return astConfirm(event, this.href, '{l s='Sync All Products' mod='aismarttalk' js=1}', '{l s='This will re-send ALL your products to AI SmartTalk, not just new ones. Existing products will be updated.' mod='aismarttalk' js=1}', 'warning');"{/if}>
                                     <span class="ast-action-icon"><i class="icon icon-refresh"></i></span>
                                     <span class="ast-action-label">{l s='Sync All Products' mod='aismarttalk'}</span>
                                 </a>
-                                <a href="{$formAction|escape:'html':'UTF-8'}&amp;clean=1" class="ast-action-btn ast-action-clean">
+                                <a href="{$formAction|escape:'html':'UTF-8'}&amp;clean=1" class="ast-action-btn ast-action-clean" {if $hasExistingProductSync}onclick="return astConfirm(event, this.href, '{l s='Clean Deleted Products' mod='aismarttalk' js=1}', '{l s='This will remove deleted and inactive products from AI SmartTalk. Active products are not affected.' mod='aismarttalk' js=1}', 'clean');"{/if}>
                                     <span class="ast-action-icon"><i class="icon icon-trash"></i></span>
                                     <span class="ast-action-label">{l s='Clean Deleted' mod='aismarttalk'}</span>
                                 </a>
@@ -2261,7 +2368,7 @@ a.ast-btn-success:hover {
                         </div>
                         <div class="ast-card-body" style="padding: 12px 24px 24px;">
                             <div class="ast-sync-actions">
-                                <a href="{$formAction|escape:'html':'UTF-8'}&amp;syncCustomers=1" class="ast-action-btn ast-action-customer">
+                                <a href="{$formAction|escape:'html':'UTF-8'}&amp;syncCustomers=1" class="ast-action-btn ast-action-customer" {if $hasExistingCustomerSync}onclick="return astConfirm(event, this.href, '{l s='Sync All Customers' mod='aismarttalk' js=1}', '{l s='This will re-send ALL your customers to AI SmartTalk, not just new ones. Existing customers will be updated.' mod='aismarttalk' js=1}', 'warning');"{/if}>
                                     <span class="ast-action-icon"><i class="icon icon-refresh"></i></span>
                                     <span class="ast-action-label">{l s='Sync All Customers' mod='aismarttalk'}</span>
                                 </a>
@@ -2684,10 +2791,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // ===== BUTTON TYPE SELECTOR =====
     var buttonTypes = document.querySelectorAll('.ast-button-type');
+    var avatarHint = document.getElementById('ast-avatar-hint');
     buttonTypes.forEach(function(btn) {
         btn.addEventListener('click', function() {
             buttonTypes.forEach(function(b) { b.classList.remove('selected'); });
             this.classList.add('selected');
+            if (avatarHint) {
+                var val = this.querySelector('input[type="radio"]').value;
+                avatarHint.style.display = (val === 'avatar') ? 'flex' : 'none';
+            }
         });
     });
 
@@ -2910,7 +3022,8 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
 
-        // On page load: expand parents of checked items
+        // On page load: expand parents of checked items and show their siblings
+        var expandedParents = {};
         Object.values(treeData).forEach(function(data) {
             if (data.checkbox && data.checkbox.checked) {
                 data.node.style.display = 'flex';
@@ -2921,11 +3034,22 @@ document.addEventListener('DOMContentLoaded', function() {
                         parentData.node.style.display = 'flex';
                         var toggle = parentData.node.querySelector('.ast-tree-toggle');
                         if (toggle) toggle.classList.add('expanded');
+                        expandedParents[parentId] = true;
                         parentId = parentData.parentId;
                     } else {
                         parentId = null;
                     }
                 }
+            }
+        });
+        // Show all direct children of expanded parents (not just checked ones)
+        Object.keys(expandedParents).forEach(function(parentId) {
+            var parentData = treeData[parseInt(parentId)];
+            if (parentData && parentData.childIds) {
+                parentData.childIds.forEach(function(childId) {
+                    var childData = treeData[childId];
+                    if (childData) childData.node.style.display = 'flex';
+                });
             }
         });
 
@@ -3359,6 +3483,45 @@ document.addEventListener('DOMContentLoaded', function() {
 
 });
 
+</script>
+
+{* ===== CONFIRM MODAL ===== *}
+<div class="ast-modal-overlay" id="astConfirmModal">
+    <div class="ast-modal">
+        <div class="ast-modal-header">
+            <div class="ast-modal-icon" id="astConfirmIcon"><i class="icon icon-warning"></i></div>
+            <h3 id="astConfirmTitle"></h3>
+        </div>
+        <div class="ast-modal-body">
+            <p id="astConfirmMessage"></p>
+        </div>
+        <div class="ast-modal-footer">
+            <button type="button" class="ast-modal-btn cancel" onclick="astConfirmClose();">{l s='Cancel' mod='aismarttalk'}</button>
+            <a href="#" class="ast-modal-btn" id="astConfirmBtn">{l s='Continue' mod='aismarttalk'}</a>
+        </div>
+    </div>
+</div>
+<script>
+function astConfirm(e, url, title, message, type) {
+    e.preventDefault();
+    var modal = document.getElementById('astConfirmModal');
+    document.getElementById('astConfirmTitle').textContent = title;
+    document.getElementById('astConfirmMessage').textContent = message;
+    var icon = document.getElementById('astConfirmIcon');
+    icon.className = 'ast-modal-icon ' + type;
+    icon.innerHTML = type === 'clean' ? '<i class="icon icon-trash"></i>' : '<i class="icon icon-warning"></i>';
+    var btn = document.getElementById('astConfirmBtn');
+    btn.className = 'ast-modal-btn confirm-' + type;
+    btn.href = url;
+    modal.classList.add('active');
+    return false;
+}
+function astConfirmClose() {
+    document.getElementById('astConfirmModal').classList.remove('active');
+}
+document.getElementById('astConfirmModal').addEventListener('click', function(e) {
+    if (e.target === this) astConfirmClose();
+});
 </script>
 
 {* ===== CHATBOT PREVIEW IN ADMIN ===== *}


### PR DESCRIPTION
## Summary
- **Always-on encryption**: AES-256-GCM payload encryption is now mandatory — removed the toggle checkbox, replaced with an "Always active" badge. Backward-compatible: API still accepts unencrypted payloads from older plugins.
- **Fix product sync category filters**: `GROUP BY` was placed before dynamic `WHERE` clauses (category filter, synced status), causing filters to be silently ignored by MySQL. Moved `GROUP BY` after all filters.
- **Fix category tree init on reload**: After saving with selected categories, only checked nodes and their ancestors were visible — sibling categories were hidden. Now all children of expanded parents are shown.
- **Fix restock hook**: `handleQuantityUpdate` was syncing restocked products without checking `shouldProductBeSynced()` category filter.
- **Avatar source of truth**: Avatar is now sourced from the platform API, not stored locally. Upload still works but clears local override. Added link to platform avatar customization.
- **Confirmation modals**: Added confirm dialogs for destructive sync actions (Force Sync All, Clean Deleted, Sync All Customers).
- **Upgrade script** (`upgrade-3.5.0.php`): Cleans up obsolete `AI_SMART_TALK_ENCRYPT_PAYLOADS` and `AI_SMART_TALK_AVATAR_URL` config keys.

## Test plan
- [ ] Verify encryption badge shows "Always active" in both PS 1.7 and PS 8 admin templates
- [ ] Test product sync with "Only selected" categories — verify correct product count
- [ ] Test product sync with "All categories" — verify all products sync
- [ ] Save category filter with a few categories, reload page — verify full tree is visible (not just checked branches)
- [ ] Update product stock to 0 then back to >0 — verify category filter is respected on restock
- [ ] Test confirmation modals on Force Sync, Clean Deleted, Sync Customers
- [ ] Upgrade from 3.4.2 — verify `AI_SMART_TALK_ENCRYPT_PAYLOADS` config key is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)