### PR TITLE
fix(compose): drop cap restrictions on prestashop service

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,13 +23,16 @@ services:
     env_file: .env
     environment:
       - DB_SERVER=prestashop_db
-    # Pas de read_only ici : l'image prestashop écrit à plusieurs endroits au
-    # runtime (init scripts, config Apache dynamique, installation PS) et
-    # restart-loop en exit 127 si on la bride. Le durcissement repose sur :
+    # Pas de read_only ni cap_drop ici : l'entrypoint PrestaShop `cp -p` des
+    # fichiers dans /var/www/html et a besoin de CAP_FOWNER/FSETID pour
+    # préserver les permissions. Sans ça, l'installation crashe au boot
+    # (cp: preserving permissions: Operation not permitted -> restart loop).
+    # Le durcissement repose sur :
     #   - module custom bind-monté en :ro (vecteur webshell bloqué)
     #   - mots de passe DB forts (.env)
     #   - iptables DOCKER-USER bloque l'UDP sortant
     #   - pas de phpMyAdmin exposé
+    #   - no-new-privileges + pids_limit + mem_limit
     volumes:
       - ./modules/aismarttalk:/var/www/html/modules/aismarttalk:ro
       - ./config/docker:/tmp/docker-config:ro
@@ -50,8 +53,6 @@ services:
       start_period: 90s
     security_opt:
       - no-new-privileges:true
-    cap_drop: [ALL]
-    cap_add: [CHOWN, SETGID, SETUID, NET_BIND_SERVICE, DAC_OVERRIDE]
     pids_limit: 300
     mem_limit: 768m
 


### PR DESCRIPTION
PrestaShop entrypoint uses `cp -p` to stage files into /var/www/html, which requires CAP_FOWNER + CAP_FSETID to preserve ownership/perms on the bind mount. With cap_drop:[ALL] + a partial whitelist, the install script failed with "cp: preserving permissions: Operation not permitted" and the container entered a restart loop.

Removing cap_drop/cap_add entirely is the pragmatic choice: PS touches many permission-sensitive paths at boot. Hardening still in place:
- no-new-privileges (blocks suid escalation)
- pids_limit + mem_limit (DoS containment)
- read-only bind mount on the custom module (webshell vector)
- DOCKER-USER iptables blocks UDP egress (host-level)

DB service keeps its cap restrictions — mysql works fine with them.