### PR TITLE
fix(deploy): auto-create defines_custom.inc.php for PS behind Caddy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,20 @@ jobs:
           set +a
 
           # Ensure runtime directories exist (non rsyncés)
-          mkdir -p data/mysql data/prestashop backups/mysql
+          mkdir -p data/mysql data/prestashop data/prestashop/config backups/mysql
+
+          # Ensure HTTPS-behind-proxy shim exists: PS ne voit pas HTTPS derrière
+          # Caddy (qui forwarde en HTTP en interne), ce qui provoque une boucle
+          # de redirection. Ce fichier est auto-chargé par PS à chaque requête.
+          if [ ! -f data/prestashop/config/defines_custom.inc.php ]; then
+            sudo tee data/prestashop/config/defines_custom.inc.php > /dev/null <<'PHPEOF'
+          <?php
+          if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+              $_SERVER['HTTPS'] = 'on';
+              $_SERVER['SERVER_PORT'] = 443;
+          }
+          PHPEOF
+          fi
 
           # Ensure scripts are executable
           chmod +x scripts/*.sh


### PR DESCRIPTION
## Summary
- PrestaShop behind Caddy was hitting `ERR_TOO_MANY_REDIRECTS` because PS doesn't trust `X-Forwarded-Proto` by default
- Auto-create `data/prestashop/config/defines_custom.inc.php` on deploy if missing — PS auto-loads it and sees `\$_SERVER['HTTPS']='on'`
- Complements the existing SQL fix (`PS_SSL_ENABLED=1`) already in deploy.yml

## Test plan
- [ ] Merge triggers CI deploy
- [ ] Fresh request to https://prestashop.demo.aismarttalk.tech returns 200 (no redirect loop)
- [ ] If `data/prestashop` is wiped and redeployed, the shim is re-created

🤖 Generated with [Claude Code](https://claude.com/claude-code)