### PR TITLE
feat(cart): endpoints panier/checkout pour l'agent IA

### DIFF
--- a/modules/aismarttalk/classes/CartGuard.php
+++ b/modules/aismarttalk/classes/CartGuard.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Copyright (c) 2026 AI SmartTalk
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ *
+ * @author    AI SmartTalk <contact@aismarttalk.tech>
+ * @copyright 2026 AI SmartTalk
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace PrestaShop\AiSmartTalk;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Authenticates the cart/checkout endpoints.
+ *
+ * Two trust paths share the same per-site HMAC secret (minted at OAuth connect):
+ *   1. Server-to-server API calls from the AI SmartTalk backend are signed with a
+ *      header signature bound to the chatModel id + a timestamp (replay window).
+ *   2. The browser-facing cart-restore link carries a short-lived capability token
+ *      bound to the cart id (so a leaked link can't be tampered with or reused forever).
+ */
+class CartGuard
+{
+    /** Allowed clock skew (seconds) for the server-to-server signature. */
+    const SIGNATURE_TTL = 300;
+
+    /** Validity window (seconds) for a browser cart-restore link. */
+    const RESTORE_TTL = 86400;
+
+    /**
+     * Verify the HMAC signature of an inbound server-to-server request.
+     *
+     * @param string $rawBody Raw request body (exact bytes that were signed)
+     *
+     * @return array{ok: bool, error: string}
+     */
+    public static function verifySignature(string $rawBody): array
+    {
+        $secret = OAuthHandler::getHmacSecret();
+        if (empty($secret)) {
+            return ['ok' => false, 'error' => 'Cart endpoint is not configured (missing shared secret). Reconnect the module.'];
+        }
+
+        $chatModelHeader = self::header('X-AIST-ChatModel');
+        $timestampHeader = self::header('X-AIST-Timestamp');
+        $signatureHeader = self::header('X-AIST-Signature');
+
+        if (empty($chatModelHeader) || empty($timestampHeader) || empty($signatureHeader)) {
+            return ['ok' => false, 'error' => 'Missing authentication headers.'];
+        }
+
+        $expectedChatModel = OAuthHandler::getChatModelId();
+        if (empty($expectedChatModel) || !hash_equals((string) $expectedChatModel, (string) $chatModelHeader)) {
+            return ['ok' => false, 'error' => 'Chat model mismatch.'];
+        }
+
+        $timestamp = (int) $timestampHeader;
+        if (abs(time() - $timestamp) > self::SIGNATURE_TTL) {
+            return ['ok' => false, 'error' => 'Request expired.'];
+        }
+
+        $expected = hash_hmac('sha256', $chatModelHeader . '.' . $timestamp . '.' . $rawBody, $secret);
+        if (!hash_equals($expected, (string) $signatureHeader)) {
+            return ['ok' => false, 'error' => 'Invalid signature.'];
+        }
+
+        return ['ok' => true, 'error' => ''];
+    }
+
+    /**
+     * Build a signed, time-bound token for a browser cart-restore link.
+     */
+    public static function makeRestoreToken(int $cartId, int $timestamp): string
+    {
+        $secret = OAuthHandler::getHmacSecret();
+
+        return hash_hmac('sha256', 'restore.' . $cartId . '.' . $timestamp, (string) $secret);
+    }
+
+    /**
+     * Verify a browser cart-restore token (signature + freshness).
+     */
+    public static function verifyRestoreToken(int $cartId, int $timestamp, string $token): bool
+    {
+        $secret = OAuthHandler::getHmacSecret();
+        if (empty($secret)) {
+            return false;
+        }
+        if (abs(time() - $timestamp) > self::RESTORE_TTL) {
+            return false;
+        }
+
+        $expected = self::makeRestoreToken($cartId, $timestamp);
+
+        return hash_equals($expected, $token);
+    }
+
+    /**
+     * Read an HTTP request header in a server-agnostic way.
+     */
+    private static function header(string $name): string
+    {
+        $serverKey = 'HTTP_' . strtoupper(str_replace('-', '_', $name));
+        if (isset($_SERVER[$serverKey])) {
+            return (string) $_SERVER[$serverKey];
+        }
+
+        if (function_exists('getallheaders')) {
+            foreach (getallheaders() as $key => $value) {
+                if (strcasecmp($key, $name) === 0) {
+                    return (string) $value;
+                }
+            }
+        }
+
+        return '';
+    }
+}

--- a/modules/aismarttalk/classes/CartService.php
+++ b/modules/aismarttalk/classes/CartService.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * Copyright (c) 2026 AI SmartTalk
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ *
+ * @author    AI SmartTalk <contact@aismarttalk.tech>
+ * @copyright 2026 AI SmartTalk
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace PrestaShop\AiSmartTalk;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Native cart operations for the AI SmartTalk agent.
+ *
+ * Built on PrestaShop's own Cart / Product / Customer classes so prices, taxes,
+ * stock checks and the checkout URL are exactly what the storefront produces. The
+ * agent prepares the cart; the shopper completes payment on the native checkout.
+ */
+class CartService
+{
+    /**
+     * Resolve a PrestaShop customer id from an explicit id or an email.
+     * Returns 0 for a guest cart.
+     */
+    public static function resolveCustomerId(?int $customerId, ?string $email): int
+    {
+        if ($customerId && $customerId > 0) {
+            $customer = new \Customer($customerId);
+            if (\Validate::isLoadedObject($customer)) {
+                return (int) $customer->id;
+            }
+        }
+
+        if (!empty($email) && \Validate::isEmail($email)) {
+            $existing = (int) \Customer::customerExists($email, true);
+            if ($existing > 0) {
+                return $existing;
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Load the shopper's working cart, or create a fresh one.
+     *
+     * Priority: an explicit (still-open) cart id → the customer's last unordered
+     * cart → a new cart. This keeps repeated add-to-cart calls accumulating into
+     * the same cart across conversation turns.
+     */
+    public static function getOrCreateCart(\Context $context, int $customerId, ?int $cartId, ?string $langIso): \Cart
+    {
+        if ($cartId) {
+            $cart = new \Cart((int) $cartId);
+            if (\Validate::isLoadedObject($cart) && !$cart->orderExists()
+                && ($customerId === 0 || (int) $cart->id_customer === $customerId)) {
+                return $cart;
+            }
+        }
+
+        if ($customerId > 0) {
+            $lastCartId = (int) \Cart::lastNoneOrderedCart($customerId);
+            if ($lastCartId) {
+                $cart = new \Cart($lastCartId);
+                if (\Validate::isLoadedObject($cart)) {
+                    return $cart;
+                }
+            }
+        }
+
+        $cart = new \Cart();
+        $cart->id_lang = self::resolveLangId($langIso, $context);
+        $cart->id_currency = (int) $context->currency->id;
+        $cart->id_shop = (int) $context->shop->id;
+        $cart->id_shop_group = (int) $context->shop->id_shop_group;
+
+        if ($customerId > 0) {
+            $customer = new \Customer($customerId);
+            $cart->id_customer = $customerId;
+            $cart->secure_key = $customer->secure_key;
+            $addressId = (int) \Address::getFirstCustomerAddressId($customerId);
+            if ($addressId) {
+                $cart->id_address_delivery = $addressId;
+                $cart->id_address_invoice = $addressId;
+            }
+        } else {
+            $cart->id_guest = (int) $context->cookie->id_guest;
+            $cart->secure_key = !empty($context->cookie->secure_key)
+                ? $context->cookie->secure_key
+                : md5(uniqid((string) mt_rand(), true));
+        }
+
+        $cart->add();
+
+        return $cart;
+    }
+
+    /**
+     * Add line items to the cart using the native quantity update (runs stock and
+     * availability checks). Returns a list of human-readable errors for skipped lines.
+     *
+     * @param array<int, array{productId?: int, attributeId?: int, quantity?: int}> $products
+     *
+     * @return string[] errors
+     */
+    public static function addProducts(\Cart $cart, array $products): array
+    {
+        $errors = [];
+
+        foreach ($products as $line) {
+            $idProduct = (int) ($line['productId'] ?? 0);
+            $idAttribute = (int) ($line['attributeId'] ?? 0);
+            $quantity = max(1, (int) ($line['quantity'] ?? 1));
+
+            if ($idProduct <= 0) {
+                continue;
+            }
+
+            $product = new \Product($idProduct, false, (int) $cart->id_lang);
+            if (!\Validate::isLoadedObject($product) || !$product->active) {
+                $errors[] = 'Product #' . $idProduct . ' is unavailable';
+                continue;
+            }
+
+            // Honour stock unless the product/shop allows ordering out of stock.
+            $available = \Product::getQuantity($idProduct, $idAttribute ?: null);
+            $allowOos = \Product::isAvailableWhenOutOfStock((int) $product->out_of_stock);
+            if (!$allowOos && $available < $quantity) {
+                $errors[] = 'Not enough stock for "' . $product->name . '" (' . (int) $available . ' left)';
+                continue;
+            }
+
+            $result = $cart->updateQty($quantity, $idProduct, $idAttribute ?: null, false, 'up');
+            if ($result === false || (is_array($result) && !empty($result))) {
+                $errors[] = 'Could not add "' . $product->name . '" to the cart';
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Normalized cart snapshot consumed by the backend / agent.
+     *
+     * @return array<string, mixed>
+     */
+    public static function snapshot(\Cart $cart): array
+    {
+        $currency = new \Currency((int) $cart->id_currency);
+        $rows = $cart->getProducts(true);
+
+        $items = [];
+        $count = 0;
+        foreach ($rows as $row) {
+            $count += (int) $row['cart_quantity'];
+            $name = $row['name'];
+            if (!empty($row['attributes_small'])) {
+                $name .= ' - ' . $row['attributes_small'];
+            } elseif (!empty($row['attributes'])) {
+                $name .= ' - ' . $row['attributes'];
+            }
+            $items[] = [
+                'productId' => (int) $row['id_product'],
+                'attributeId' => (int) ($row['id_product_attribute'] ?? 0),
+                'name' => $name,
+                'quantity' => (int) $row['cart_quantity'],
+                'unitPrice' => \Tools::displayPrice((float) $row['price_wt'], $currency),
+                'totalPrice' => \Tools::displayPrice((float) $row['total_wt'], $currency),
+            ];
+        }
+
+        $total = (float) $cart->getOrderTotal(true, \Cart::BOTH);
+
+        return [
+            'cartId' => (int) $cart->id,
+            'currency' => $currency->iso_code,
+            'currencySign' => $currency->sign,
+            'itemCount' => $count,
+            'total' => \Tools::displayPrice($total, $currency),
+            'totalRaw' => round($total, 2),
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * Build the browser cart-restore / checkout URL pointing back to this module's
+     * `restore` action, signed and time-bound (see CartGuard).
+     */
+    public static function buildCheckoutUrl(\Cart $cart): string
+    {
+        $timestamp = time();
+        $token = CartGuard::makeRestoreToken((int) $cart->id, $timestamp);
+        $base = rtrim(\Tools::getShopDomainSsl(true), '/');
+
+        return $base . '/index.php?fc=module&module=aismarttalk&controller=cart&action=restore'
+            . '&cartId=' . (int) $cart->id
+            . '&ts=' . $timestamp
+            . '&t=' . $token;
+    }
+
+    /**
+     * Resolve a front-office language id from an ISO code, falling back to context.
+     */
+    private static function resolveLangId(?string $langIso, \Context $context): int
+    {
+        if (!empty($langIso)) {
+            $id = (int) \Language::getIdByIso(\Tools::substr($langIso, 0, 2));
+            if ($id) {
+                return $id;
+            }
+        }
+
+        return (int) $context->language->id;
+    }
+}

--- a/modules/aismarttalk/classes/OAuthHandler.php
+++ b/modules/aismarttalk/classes/OAuthHandler.php
@@ -420,6 +420,12 @@ class OAuthHandler
             MultistoreHelper::updateConfig('AI_SMART_TALK_SITE_IDENTIFIER', $tokenData['site_identifier']);
         }
 
+        // Store the shared HMAC secret used to verify server-to-server cart/checkout
+        // calls coming from the AI SmartTalk backend (see CartGuard / cart controller).
+        if (!empty($tokenData['hmac_secret'])) {
+            MultistoreHelper::updateConfig('AI_SMART_TALK_HMAC_SECRET', $tokenData['hmac_secret']);
+        }
+
         // For backward compatibility, also update the old config keys
         MultistoreHelper::updateConfig('CHAT_MODEL_ID', $tokenData['chat_model_id']);
         MultistoreHelper::updateConfig('CHAT_MODEL_TOKEN', $tokenData['access_token']);
@@ -548,6 +554,19 @@ class OAuthHandler
         $id = MultistoreHelper::getConfig('AI_SMART_TALK_CHAT_MODEL_ID');
 
         return !empty($id) ? $id : null;
+    }
+
+    /**
+     * Get the shared HMAC secret used to authenticate cart/checkout calls from the
+     * AI SmartTalk backend.
+     *
+     * @return string|null
+     */
+    public static function getHmacSecret(): ?string
+    {
+        $secret = MultistoreHelper::getConfig('AI_SMART_TALK_HMAC_SECRET');
+
+        return !empty($secret) ? $secret : null;
     }
 
     /**

--- a/modules/aismarttalk/controllers/front/cart.php
+++ b/modules/aismarttalk/controllers/front/cart.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Copyright (c) 2026 AI SmartTalk
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ *
+ * Cart Front Controller
+ *
+ * Two roles:
+ *   - POST (server-to-server, HMAC-signed): the AI SmartTalk backend builds the
+ *     shopper's cart (add / get / checkoutUrl) using native PrestaShop classes.
+ *   - GET ?action=restore (browser, capability token): loads the prepared cart into
+ *     the shopper's session and forwards to the native checkout for payment.
+ *
+ * @author    AI SmartTalk <contact@aismarttalk.tech>
+ * @copyright 2026 AI SmartTalk
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+require_once _PS_MODULE_DIR_ . 'aismarttalk/vendor/autoload.php';
+
+use PrestaShop\AiSmartTalk\CartGuard;
+use PrestaShop\AiSmartTalk\CartService;
+
+class AismarttalkCartModuleFrontController extends ModuleFrontController
+{
+    public $ssl = true;
+    public $auth = false;
+    public $guestAllowed = true;
+
+    public function initContent()
+    {
+        // Browser-facing capability link: restore the prepared cart, then checkout.
+        if (Tools::getValue('action') === 'restore') {
+            $this->handleRestore();
+
+            return;
+        }
+
+        // Server-to-server JSON API (HMAC-signed).
+        $this->handleApi();
+    }
+
+    /**
+     * Handle the signed JSON API (add / get / checkoutUrl).
+     */
+    private function handleApi(): void
+    {
+        $rawBody = (string) file_get_contents('php://input');
+
+        $auth = CartGuard::verifySignature($rawBody);
+        if (!$auth['ok']) {
+            $this->respond(401, ['success' => false, 'error' => $auth['error']]);
+
+            return;
+        }
+
+        $payload = json_decode($rawBody, true);
+        if (!is_array($payload)) {
+            $this->respond(400, ['success' => false, 'error' => 'Invalid JSON body.']);
+
+            return;
+        }
+
+        $action = isset($payload['action']) ? (string) $payload['action'] : '';
+        $customerId = isset($payload['customerId']) ? (int) $payload['customerId'] : 0;
+        $email = isset($payload['email']) ? (string) $payload['email'] : null;
+        $cartId = isset($payload['cartId']) ? (int) $payload['cartId'] : null;
+        $langIso = isset($payload['langIso']) ? (string) $payload['langIso'] : null;
+
+        try {
+            $resolvedCustomerId = CartService::resolveCustomerId($customerId, $email);
+            $cart = CartService::getOrCreateCart($this->context, $resolvedCustomerId, $cartId, $langIso);
+
+            $warnings = [];
+
+            if ($action === 'add') {
+                $products = isset($payload['products']) && is_array($payload['products'])
+                    ? $payload['products']
+                    : [];
+                if (empty($products)) {
+                    $this->respond(400, ['success' => false, 'error' => 'No products provided.']);
+
+                    return;
+                }
+                $warnings = CartService::addProducts($cart, $products);
+            } elseif ($action !== 'get' && $action !== 'checkoutUrl') {
+                $this->respond(400, ['success' => false, 'error' => 'Unknown action: ' . $action]);
+
+                return;
+            }
+
+            $snapshot = CartService::snapshot($cart);
+
+            // A successful add that put nothing in an empty cart is an error.
+            if ($action === 'add' && $snapshot['itemCount'] === 0) {
+                $this->respond(400, [
+                    'success' => false,
+                    'error' => !empty($warnings) ? implode('; ', $warnings) : 'No product could be added to the cart.',
+                ]);
+
+                return;
+            }
+
+            $checkoutUrl = null;
+            if ($action === 'checkoutUrl') {
+                if ($snapshot['itemCount'] === 0) {
+                    $this->respond(400, ['success' => false, 'error' => 'The cart is empty.']);
+
+                    return;
+                }
+                $checkoutUrl = CartService::buildCheckoutUrl($cart);
+            }
+
+            $response = array_merge($snapshot, [
+                'success' => true,
+                'checkoutUrl' => $checkoutUrl,
+                'warnings' => $warnings,
+                'message' => $this->buildMessage($action, $snapshot, $checkoutUrl, $warnings),
+            ]);
+
+            $this->respond(200, $response);
+        } catch (\Throwable $e) {
+            PrestaShopLogger::addLog(
+                'AI SmartTalk cart error: ' . $e->getMessage(),
+                3,
+                null,
+                'AiSmartTalk',
+                null,
+                true
+            );
+            $this->respond(500, ['success' => false, 'error' => 'Cart operation failed.']);
+        }
+    }
+
+    /**
+     * Restore a prepared cart into the shopper's session and forward to checkout.
+     */
+    private function handleRestore(): void
+    {
+        $cartId = (int) Tools::getValue('cartId');
+        $timestamp = (int) Tools::getValue('ts');
+        $token = (string) Tools::getValue('t');
+
+        if (!$cartId || !CartGuard::verifyRestoreToken($cartId, $timestamp, $token)) {
+            Tools::redirect($this->context->link->getPageLink('index'));
+
+            return;
+        }
+
+        $cart = new Cart($cartId);
+        if (!Validate::isLoadedObject($cart) || $cart->orderExists()) {
+            Tools::redirect($this->context->link->getPageLink('index'));
+
+            return;
+        }
+
+        // Load the prepared cart into the current session so the native checkout uses it.
+        $this->context->cookie->id_cart = (int) $cart->id;
+        $this->context->cookie->write();
+
+        Tools::redirect($this->context->link->getPageLink('order', true, (int) $cart->id_lang));
+    }
+
+    /**
+     * Build a concise, shopper-facing message the assistant can relay.
+     *
+     * @param array<string, mixed> $snapshot
+     * @param string[]             $warnings
+     */
+    private function buildMessage(string $action, array $snapshot, ?string $checkoutUrl, array $warnings): string
+    {
+        $count = (int) $snapshot['itemCount'];
+        $total = (string) $snapshot['total'];
+
+        if ($action === 'checkoutUrl') {
+            $message = sprintf('Your cart has %d item(s) for a total of %s.', $count, $total);
+            if ($checkoutUrl) {
+                $message .= ' Complete your order here: ' . $checkoutUrl;
+            }
+
+            return $message;
+        }
+
+        if ($action === 'add') {
+            $message = sprintf('Added to your cart. You now have %d item(s) for a total of %s.', $count, $total);
+        } else {
+            $message = sprintf('Your cart has %d item(s) for a total of %s.', $count, $total);
+        }
+
+        if (!empty($warnings)) {
+            $message .= ' Note: ' . implode('; ', $warnings) . '.';
+        }
+
+        return $message;
+    }
+
+    /**
+     * Emit a JSON response and stop — never render the storefront template.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function respond(int $status, array $data): void
+    {
+        if (!headers_sent()) {
+            http_response_code($status);
+            header('Content-Type: application/json');
+            header('Cache-Control: no-store');
+        }
+        echo json_encode($data);
+        exit;
+    }
+}

--- a/modules/aismarttalk/vendor/composer/autoload_classmap.php
+++ b/modules/aismarttalk/vendor/composer/autoload_classmap.php
@@ -14,6 +14,8 @@ return array(
     'PrestaShop\\AiSmartTalk\\AiSmartTalkProductSync' => $baseDir . '/classes/AiSmartTalkProductSync.php',
     'PrestaShop\\AiSmartTalk\\ApiClient' => $baseDir . '/classes/ApiClient.php',
     'PrestaShop\\AiSmartTalk\\ApiResponse' => $baseDir . '/classes/ApiResponse.php',
+    'PrestaShop\\AiSmartTalk\\CartGuard' => $baseDir . '/classes/CartGuard.php',
+    'PrestaShop\\AiSmartTalk\\CartService' => $baseDir . '/classes/CartService.php',
     'PrestaShop\\AiSmartTalk\\ChatbotSettingsBuilder' => $baseDir . '/classes/ChatbotSettingsBuilder.php',
     'PrestaShop\\AiSmartTalk\\CleanProductDocuments' => $baseDir . '/classes/CleanProductDocuments.php',
     'PrestaShop\\AiSmartTalk\\CombinationHelper' => $baseDir . '/classes/CombinationHelper.php',

--- a/modules/aismarttalk/vendor/composer/autoload_real.php
+++ b/modules/aismarttalk/vendor/composer/autoload_real.php
@@ -29,7 +29,6 @@ class ComposerAutoloaderInit3bdbd939a184a583fcb24dad87c35c72
         require __DIR__ . '/autoload_static.php';
         call_user_func(\Composer\Autoload\ComposerStaticInit3bdbd939a184a583fcb24dad87c35c72::getInitializer($loader));
 
-        $loader->setClassMapAuthoritative(true);
         $loader->register(false);
 
         return $loader;

--- a/modules/aismarttalk/vendor/composer/autoload_static.php
+++ b/modules/aismarttalk/vendor/composer/autoload_static.php
@@ -29,6 +29,8 @@ class ComposerStaticInit3bdbd939a184a583fcb24dad87c35c72
         'PrestaShop\\AiSmartTalk\\AiSmartTalkProductSync' => __DIR__ . '/../..' . '/classes/AiSmartTalkProductSync.php',
         'PrestaShop\\AiSmartTalk\\ApiClient' => __DIR__ . '/../..' . '/classes/ApiClient.php',
         'PrestaShop\\AiSmartTalk\\ApiResponse' => __DIR__ . '/../..' . '/classes/ApiResponse.php',
+        'PrestaShop\\AiSmartTalk\\CartGuard' => __DIR__ . '/../..' . '/classes/CartGuard.php',
+        'PrestaShop\\AiSmartTalk\\CartService' => __DIR__ . '/../..' . '/classes/CartService.php',
         'PrestaShop\\AiSmartTalk\\ChatbotSettingsBuilder' => __DIR__ . '/../..' . '/classes/ChatbotSettingsBuilder.php',
         'PrestaShop\\AiSmartTalk\\CleanProductDocuments' => __DIR__ . '/../..' . '/classes/CleanProductDocuments.php',
         'PrestaShop\\AiSmartTalk\\CombinationHelper' => __DIR__ . '/../..' . '/classes/CombinationHelper.php',


### PR DESCRIPTION
## Objectif
Exposer au backend AI SmartTalk des endpoints **panier / checkout** pour que l'agent puisse ajouter au panier et amener le client au paiement, en s'appuyant sur les classes natives PrestaShop.

## Contenu
- **`controllers/front/cart.php`** — un front-controller, deux rôles :
  - **POST signé HMAC** (server-to-server) : `add` / `get` / `checkoutUrl`.
  - **GET `?action=restore`** (navigateur, token capability) : charge le panier préparé en session puis redirige vers le checkout natif.
- **`classes/CartService.php`** — résolution client (id → email → invité), panier serveur réutilisable, contrôle de stock, snapshot prix/taxes, lien de restore.
- **`classes/CartGuard.php`** — vérif signature HMAC (anti-rejeu 300 s) + token de restore signé (24 h).
- **`classes/OAuthHandler.php`** — stockage du secret HMAC partagé minté par le backend à la connexion OAuth.

## Sécurité
Toutes les écritures sont signées avec un secret HMAC par site (jamais exposé au navigateur). Le paiement reste **natif** : l'agent prépare le panier, le client paie sur la boutique.

## Notes
- Pas de bump de version (laissé au release tooling) pour ne pas entrer en conflit avec les branches en cours.
- PR jumelle côté backend : AI-SmartTalk/aismarttalk#1673.
- `php -l` OK ; autoload Composer régénéré (CartGuard/CartService).

🤖 Generated with [Claude Code](https://claude.com/claude-code)