### PR TITLE
feat(sync): restockDate dans le ProductDocument canonique (DEV-857)

### DIFF
--- a/modules/aismarttalk/classes/ProductDocumentBuilder.php
+++ b/modules/aismarttalk/classes/ProductDocumentBuilder.php
@@ -74,11 +74,13 @@ class ProductDocumentBuilder
         // `optional()` so a null value (invalid currency, no description,
         // simple product without variants…) gets omitted from the envelope
         // rather than sent as a noisy `null`.
+        $availability = self::deriveAvailability($legacy);
+
         $document = [
             'type' => 'product',
             'externalId' => $externalId,
             'title' => $title !== '' ? $title : $externalId,
-            'availability' => self::deriveAvailability($legacy),
+            'availability' => $availability,
             'variants' => self::buildVariants($externalId, $legacy['variants'] ?? []),
         ];
 
@@ -93,6 +95,7 @@ class ProductDocumentBuilder
             ),
             'reference' => self::nullableString($legacy['reference'] ?? null),
             'quantity' => self::normaliseQuantity($legacy['quantity'] ?? null),
+            'restockDate' => self::deriveRestockDate($legacy, $availability),
             'image' => self::nullableString($legacy['image_url'] ?? $legacy['image'] ?? null),
             'url' => self::nullableString($legacy['url'] ?? null),
             'categories' => self::collectStringList($legacy['categories'] ?? null),
@@ -261,6 +264,55 @@ class ProductDocumentBuilder
             return ((int) $legacy['quantity']) > 0 ? self::STOCK_IN : self::STOCK_OUT;
         }
         return self::STOCK_UNKNOWN;
+    }
+
+    /**
+     * Resolve the expected back-in-stock date.
+     *
+     * Only meaningful when the product is NOT in stock — an in-stock product has
+     * nothing to restock. Reads `restock_date` / `restockDate` (the sync feeds it
+     * from PrestaShop's `product.available_date`). Returns an ISO-8601 day
+     * ("YYYY-MM-DD") or null.
+     *
+     * @param array<string,mixed> $legacy
+     */
+    private static function deriveRestockDate(array $legacy, string $availability): ?string
+    {
+        if ($availability === self::STOCK_IN) {
+            return null;
+        }
+        $raw = $legacy['restock_date'] ?? $legacy['restockDate'] ?? null;
+        return self::normaliseRestockDate($raw);
+    }
+
+    /**
+     * Normalise a raw date to a bare ISO-8601 day ("YYYY-MM-DD") or null.
+     *
+     * Accepts a date or datetime; rejects empty values, zero-dates and impossible
+     * calendar dates. Parity with the canonical server schema (OptionalIsoDate)
+     * and the other connectors so AI SmartTalk gets one shape from every source.
+     *
+     * @param mixed $raw
+     */
+    private static function normaliseRestockDate($raw): ?string
+    {
+        if ($raw === null || !is_scalar($raw)) {
+            return null;
+        }
+        $trimmed = trim((string) $raw);
+        if ($trimmed === '' || strpos($trimmed, '0000-00-00') === 0) {
+            return null;
+        }
+        if (preg_match('/^(\d{4})-(\d{2})-(\d{2})/', $trimmed, $m) !== 1) {
+            return null;
+        }
+        $year = (int) $m[1];
+        $month = (int) $m[2];
+        $day = (int) $m[3];
+        if ($year <= 0 || !checkdate($month, $day, $year)) {
+            return null;
+        }
+        return sprintf('%04d-%02d-%02d', $year, $month, $day);
     }
 
     private static function normalisePrice($raw): ?string

--- a/modules/aismarttalk/classes/SynchProductsToAiSmartTalk.php
+++ b/modules/aismarttalk/classes/SynchProductsToAiSmartTalk.php
@@ -165,6 +165,9 @@ class SynchProductsToAiSmartTalk
                 'url' => $productUrl,
                 'image_url' => $imageUrl,
                 'variants' => $variants,
+                // Back-in-stock date — PrestaShop's product.available_date. The
+                // builder normalises it and only keeps it when out of stock.
+                'restock_date' => $product['available_date'] ?? null,
             ];
 
             if (count($documentDatas) === 10) {

--- a/modules/aismarttalk/tests/ProductDocumentBuilderTest.php
+++ b/modules/aismarttalk/tests/ProductDocumentBuilderTest.php
@@ -289,6 +289,69 @@ class ProductDocumentBuilderTest extends TestCase
     }
 
     // =========================================================================
+    // Unified stock / restock date (DEV-857 — same standard across connectors)
+    // =========================================================================
+
+    public function testInStockProductNeverEmitsRestockDate(): void
+    {
+        $doc = ProductDocumentBuilder::build([
+            'id' => 100,
+            'title' => 'Available',
+            'quantity' => 5,
+            'restock_date' => '2026-06-15',
+        ]);
+        self::assertSame('in_stock', $doc['availability']);
+        self::assertArrayNotHasKey('restockDate', $doc);
+    }
+
+    public function testOutOfStockWithoutDateOmitsRestockDate(): void
+    {
+        $doc = ProductDocumentBuilder::build([
+            'id' => 101,
+            'title' => 'Sold out',
+            'quantity' => 0,
+        ]);
+        self::assertSame('out_of_stock', $doc['availability']);
+        self::assertArrayNotHasKey('restockDate', $doc);
+    }
+
+    public function testOutOfStockWithDateEmitsRestockDate(): void
+    {
+        $doc = ProductDocumentBuilder::build([
+            'id' => 102,
+            'title' => 'Back soon',
+            'quantity' => 0,
+            'restock_date' => '2026-06-15',
+        ]);
+        self::assertSame('out_of_stock', $doc['availability']);
+        self::assertSame('2026-06-15', $doc['restockDate']);
+    }
+
+    public function testRestockDateNormalisesDatetimeToIsoDay(): void
+    {
+        $doc = ProductDocumentBuilder::build([
+            'id' => 103,
+            'title' => 'Back soon',
+            'quantity' => 0,
+            'restock_date' => '2026-06-15 09:30:00',
+        ]);
+        self::assertSame('2026-06-15', $doc['restockDate']);
+    }
+
+    public function testRestockDateRejectsZeroAndMalformedDates(): void
+    {
+        foreach (['0000-00-00', 'not-a-date', '2026-02-30'] as $bad) {
+            $doc = ProductDocumentBuilder::build([
+                'id' => 104,
+                'title' => 'Sold out',
+                'quantity' => 0,
+                'restock_date' => $bad,
+            ]);
+            self::assertArrayNotHasKey('restockDate', $doc, "Expected restockDate dropped for: {$bad}");
+        }
+    }
+
+    // =========================================================================
     // Failure mode
     // =========================================================================
 


### PR DESCRIPTION
## Contexte

Retour **Dotit** (22/05/2026) : l'agent doit pouvoir répondre « *Indisponible actuellement, réappro prévu le {date}* ». Objectif : **un seul format produit, identique quelle que soit la source**.

Cette PR aligne **PrestaShop** (déjà migré au `ProductDocument` canonique sur `feat/v1-canonical-sync`) sur le standard de réappro, exactement comme les autres connecteurs.

## Changement

- **`ProductDocumentBuilder`** : nouveau champ **`restockDate`** (`"YYYY-MM-DD"` ou omis), renseigné **uniquement** quand le produit n'est pas en stock. `normaliseRestockDate()` tronque un datetime au jour, rejette zéro-dates et dates calendaires impossibles.
- **`SynchProductsToAiSmartTalk`** : alimente `restock_date` depuis `product.available_date` (déjà sélectionné en SQL).

Même clé (`restockDate`) et même normalisation que WooCommerce #54 / Shopify #12 / Joomla #12 et que le schéma canonique serveur (aismarttalk #1675, qui ajoute `restockDate` à `canonical.ts` + `v1.json`).

## Tests

5 tests PHPUnit, dont les **3 cas d'acceptation** : en stock / rupture sans date / rupture avec date (+ datetime normalisé, + zéro/dates malformées ignorées). `phpunit` vert (25 tests).

## Notes

- Empilée sur `feat/v1-canonical-sync` (la migration canonique PrestaShop).
- Côté serveur, l'acceptation du champ (schéma `.strict()`) + l'indexation/rendu sont dans aismarttalk #1675 ; l'exposition au LLM + la consigne de réponse dans aismarttalk #1674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)